### PR TITLE
Sync dist_utils.py with latest from st2 repo

### DIFF
--- a/dist_utils.py
+++ b/dist_utils.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-# Licensed to the StackStorm, Inc ('StackStorm') under one or more
-# contributor license agreements.  See the NOTICE file distributed with
-# this work for additional information regarding copyright ownership.
-# The ASF licenses this file to You under the Apache License, Version 2.0
-# (the "License"); you may not use this file except in compliance with
-# the License.  You may obtain a copy of the License at
+# NOTE: This file is auto-generated - DO NOT EDIT MANUALLY
+#       Instead copy from https://github.com/StackStorm/st2/blob/master/scripts/dist_utils.py
+
+# Copyright 2019 Extreme Networks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
@@ -15,37 +17,36 @@
 # limitations under the License.
 
 from __future__ import absolute_import
+
 import os
 import re
 import sys
 
 from distutils.version import StrictVersion
 
+# NOTE: This script can't rely on any 3rd party dependency so we need to use this code here
+#
+# TODO: Why can't this script rely on 3rd party dependencies? Is it because it has to import
+#       from pip?
+#
+# TODO: Dear future developer, if you are back here fixing a bug with how we parse
+#       requirements files, please look into using the packaging package on PyPI:
+#       https://packaging.pypa.io/en/latest/requirements/
+#       and specifying that in the `setup_requires` argument to `setuptools.setup()`
+#       for subpackages.
+#       At the very least we can vendorize some of their code instead of reimplementing
+#       each piece of their code every time our parsing breaks.
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    text_type = str
+else:
+    text_type = unicode  # NOQA
+
 GET_PIP = 'curl https://bootstrap.pypa.io/get-pip.py | python'
 
-try:
-    import pip
-    from pip import __version__ as pip_version
-except ImportError as e:
-    print('Failed to import pip: %s' % (str(e)))
-    print('')
-    print('Download pip:\n%s' % (GET_PIP))
-    sys.exit(1)
-
-try:
-    # pip < 10.0
-    from pip.req import parse_requirements
-except ImportError:
-    # pip >= 10.0
-
-    try:
-        from pip._internal.req.req_file import parse_requirements
-    except ImportError as e:
-        print('Failed to import parse_requirements from pip: %s' % (str(e)))
-        print('Using pip: %s' % (str(pip_version)))
-        sys.exit(1)
-
 __all__ = [
+    'check_pip_is_installed',
     'check_pip_version',
     'fetch_requirements',
     'apply_vagrant_workaround',
@@ -54,14 +55,37 @@ __all__ = [
 ]
 
 
-def check_pip_version():
+def check_pip_is_installed():
+    """
+    Ensure that pip is installed.
+    """
+    try:
+        import pip  # NOQA
+    except ImportError as e:
+        print('Failed to import pip: %s' % (text_type(e)))
+        print('')
+        print('Download pip:\n%s' % (GET_PIP))
+        sys.exit(1)
+
+    return True
+
+
+def check_pip_version(min_version='6.0.0'):
     """
     Ensure that a minimum supported version of pip is installed.
     """
-    if StrictVersion(pip.__version__) < StrictVersion('6.0.0'):
-        print("Upgrade pip, your version `{0}' "
-              "is outdated:\n{1}".format(pip.__version__, GET_PIP))
+    check_pip_is_installed()
+
+    import pip
+
+    if StrictVersion(pip.__version__) < StrictVersion(min_version):
+        print("Upgrade pip, your version '{0}' "
+              "is outdated. Minimum required version is '{1}':\n{2}".format(pip.__version__,
+                                                                            min_version,
+                                                                            GET_PIP))
         sys.exit(1)
+
+    return True
 
 
 def fetch_requirements(requirements_file_path):
@@ -70,10 +94,46 @@ def fetch_requirements(requirements_file_path):
     """
     links = []
     reqs = []
-    for req in parse_requirements(requirements_file_path, session=False):
-        if req.link:
-            links.append(str(req.link))
-        reqs.append(str(req.req))
+
+    def _get_link(line):
+        vcs_prefixes = ['git+', 'svn+', 'hg+', 'bzr+']
+
+        for vcs_prefix in vcs_prefixes:
+            if line.startswith(vcs_prefix) or line.startswith('-e %s' % (vcs_prefix)):
+                req_name = re.findall('.*#egg=(.+)([&|@]).*$', line)
+
+                if not req_name:
+                    req_name = re.findall('.*#egg=(.+?)$', line)
+                else:
+                    req_name = req_name[0]
+
+                if not req_name:
+                    raise ValueError('Line "%s" is missing "#egg=<package name>"' % (line))
+
+                link = line.replace('-e ', '').strip()
+                return link, req_name[0]
+
+        return None, None
+
+    with open(requirements_file_path, 'r') as fp:
+        for line in fp.readlines():
+            line = line.strip()
+
+            if line.startswith('#') or not line:
+                continue
+
+            link, req_name = _get_link(line=line)
+
+            if link:
+                links.append(link)
+            else:
+                req_name = line
+
+                if ';' in req_name:
+                    req_name = req_name.split(';')[0].strip()
+
+            reqs.append(req_name)
+
     return (reqs, links)
 
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,6 +1,6 @@
-unittest2
-mock>=1.0
-pep8>=1.6.0,<1.7
-flake8>=2.3.0,<2.4
-pylint>=1.4.3,<1.5
+mock==3.0.5
 nose>=1.3.7
+pep8==1.7.1
+pylint==1.9.4
+st2flake8==0.1.0
+unittest2


### PR DESCRIPTION
Sync dist_utils.py with latest from st2 repo

Fix is related to: https://github.com/StackStorm/st2/pull/4929

Fixes error in CI: https://travis-ci.org/github/StackStorm/st2/jobs/681137227

```shell
    ERROR: Command errored out with exit status 1:
     command: /home/travis/build/StackStorm/st2/virtualenv/bin/python2.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-BVwhVy/st2-auth-backend-flat-file/setup.py'"'"'; __file__='"'"'/tmp/pip-install-BVwhVy/st2-auth-backend-flat-file/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-mhz4SU
         cwd: /tmp/pip-install-BVwhVy/st2-auth-backend-flat-file/
    Complete output (7 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-install-BVwhVy/st2-auth-backend-flat-file/setup.py", line 32, in <module>
        install_reqs, dep_links = fetch_requirements(REQUIREMENTS_FILE)
      File "dist_utils.py", line 74, in fetch_requirements
        if req.link:
    AttributeError: 'ParsedRequirement' object has no attribute 'link'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```

